### PR TITLE
change the node of photos

### DIFF
--- a/lib/flickr.rb
+++ b/lib/flickr.rb
@@ -223,7 +223,7 @@ class Flickr
     # depending on the original object the photos are related to (e.g 'photos',
     # 'photoset', etc)
     def initialize(photos_api_response={}, api_key={})
-      photos = photos_api_response.values.first 
+      photos = photos_api_response['photos']
       [ "page", "pages", "perpage", "total" ].each { |i| instance_variable_set("@#{i}", photos[i])} 
       collection = photos['photo'] || []
       collection = [collection] if collection.is_a? Hash


### PR DESCRIPTION
I modified the node of the photos because it could not get the node of the photos by `photos = photos_api_response.values.first`.
