### PR TITLE
making photos_requests compatible with latest changes to flickrAPI responses

### DIFF
--- a/lib/flickr.rb
+++ b/lib/flickr.rb
@@ -188,9 +188,9 @@ class Flickr
   end
 
   # acts like request but returns a PhotoCollection (a list of Photo objects)
-  def photos_request(method, params={})
+  def photos_request(method, params={}, list_node="photos")
     photos = request(method, params)
-    PhotoCollection.new(photos, @api_key)
+    PhotoCollection.new(photos, @api_key, list_node)
   end
 
   # Builds url for Flickr API REST request from given the flickr method name
@@ -222,8 +222,8 @@ class Flickr
     # the first (and only) key-value pair of the response. The key will vary
     # depending on the original object the photos are related to (e.g 'photos',
     # 'photoset', etc)
-    def initialize(photos_api_response={}, api_key={})
-      photos = photos_api_response.values.first
+    def initialize(photos_api_response={}, api_key={}, list_node="photos")
+      photos = photos_api_response[list_node]
       [ "page", "pages", "perpage", "total" ].each { |i| instance_variable_set("@#{i}", photos[i])}
       collection = photos['photo'] || []
       collection = [collection] if collection.is_a? Hash
@@ -726,7 +726,7 @@ class Flickr
     end
 
     def getPhotos
-      photosetPhotos = @client.photos_request('photosets.getPhotos', {'photoset_id' => @id})
+      photosetPhotos = @client.photos_request('photosets.getPhotos', {'photoset_id' => @id}, "photoset")
     end
 
   end

--- a/test/flickr_test.rb
+++ b/test/flickr_test.rb
@@ -968,7 +968,8 @@ class TestFlickr < Test::Unit::TestCase
   end
 
   def dummy_photos_response
-    { "photos" =>
+    { "stat"=>"ok",
+      "photos" =>
       { "photo" =>
         [{ "id" => "foo123",
            "key1" => "value1",
@@ -982,7 +983,8 @@ class TestFlickr < Test::Unit::TestCase
   end
 
   def dummy_single_photo_response
-    { "photos" =>
+    { "stat"=>"ok",
+      "photos" =>
       { "photo" =>
         { "id" => "foo123",
           "key1" => "value1",
@@ -990,7 +992,7 @@ class TestFlickr < Test::Unit::TestCase
   end
 
   def dummy_zero_photo_response
-    { "photos" => { "total" => 0 } }
+    { "stat"=>"ok", "photos" => { "total" => 0 } }
   end
 
   def dummy_user_response
@@ -1020,7 +1022,7 @@ class TestFlickr < Test::Unit::TestCase
   end
 
   def dummy_photoset_photos_response
-    { "photoset" =>
+    { "stat"=>"ok", "photoset" =>
       { "photo" =>
         [{ "id" => "foo123",
            "key1" => "value1",


### PR DESCRIPTION
I have reviewed the changes to Flickr API and fixes gem to be compatible with new format of responses for photos lists.

It fixes #1 and fixes #2 Issues. 

I will release a new gem version - 1.1.1 - with this change.
